### PR TITLE
[Fixes #22] add version number to migration templates

### DIFF
--- a/lib/generators/rails-push-notifications/templates/migrations/create_rails_push_notifications_apps.rb
+++ b/lib/generators/rails-push-notifications/templates/migrations/create_rails_push_notifications_apps.rb
@@ -1,4 +1,4 @@
-class CreateRailsPushNotificationsApps < ActiveRecord::Migration
+class CreateRailsPushNotificationsApps < ActiveRecord::Migration[4.2]
   def self.up
     create_table :rails_push_notifications_apns_apps do |t|
       t.text :apns_dev_cert

--- a/lib/generators/rails-push-notifications/templates/migrations/create_rails_push_notifications_notifications.rb
+++ b/lib/generators/rails-push-notifications/templates/migrations/create_rails_push_notifications_notifications.rb
@@ -1,4 +1,4 @@
-class CreateRailsPushNotificationsNotifications < ActiveRecord::Migration
+class CreateRailsPushNotificationsNotifications < ActiveRecord::Migration[4.2]
   def change
     create_table :rails_push_notifications_notifications do |t|
       t.text :destinations


### PR DESCRIPTION
Hi,

this PR fixes #22 by adding version numbers to the migration templates.